### PR TITLE
Maturing the experiments on MNIST 

### DIFF
--- a/TEST_TripleReg_mnist.py
+++ b/TEST_TripleReg_mnist.py
@@ -29,11 +29,11 @@ import os, sys, pickle
 """
 SET SEED FOR reproducable RESULTS
 """
-os.environ["PYTHONHASHSEED"] = "0"
-np.random.seed(1234)
-rn.seed(1234)
-# session_conf = tf.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
-tf.set_random_seed(1234)
+os.environ["PYTHONHASHSEED"] = "1000"
+np.random.seed(1000)
+rn.seed(1000)
+# # session_conf = tf.ConfigProto(intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
+tf.set_random_seed(1000)
 # sess = tf.Session(graph=tf.get_default_graph(), config=session_conf)
 # K.set_session(sess)
 ################################
@@ -220,7 +220,7 @@ test_dgen_obj = test_dgen()
 history = model.fit_generator(
     dgen,
     steps_per_epoch=20,
-    epochs=100,
+    epochs=20,
     validation_data = test_dgen_obj,
     validation_steps = 1,
     callbacks=[lrreduce]

--- a/VIZ_mnist_runs.py
+++ b/VIZ_mnist_runs.py
@@ -1,0 +1,24 @@
+from __future__ import print_function, division 
+import numpy as np 
+import matplotlib.pyplot as plt 
+import os, sys, time, pickle 
+
+files = os.listdir("./") 
+clean_files = [] 
+for f in files:
+    if "run" in f:
+        if os.path.isfile(os.path.join("./",f,"params.txt")) and os.path.isfile(os.path.join("./",f,"history.pkl")) :
+            clean_files.append(f) 
+
+print("Found folders: ", clean_files) 
+
+for folder in clean_files:
+    with open(os.path.join("./",folder,"params.txt"), "rt") as f:
+        parameters_str = f.read() 
+    with open(os.path.join("./", folder, "history.pkl"), "rb") as f:
+        history_dict = pickle.load(f) 
+    
+    assert "val_preds_acc" in history_dict.keys(), "val_preds_acc not available for ", folder
+    plt.plot(np.arange(50), history_dict["val_preds_acc"])
+plt.show() 
+

--- a/VIZ_mnist_runs.py
+++ b/VIZ_mnist_runs.py
@@ -19,6 +19,7 @@ for folder in clean_files:
         history_dict = pickle.load(f) 
     
     assert "val_preds_acc" in history_dict.keys(), "val_preds_acc not available "
-    plt.plot(np.arange(50), history_dict["val_preds_acc"])
+    plt.plot(np.arange(50), history_dict["val_preds_acc"], label=parameters_str)
+plt.legend() 
 plt.show() 
 

--- a/VIZ_mnist_runs.py
+++ b/VIZ_mnist_runs.py
@@ -18,7 +18,7 @@ for folder in clean_files:
     with open(os.path.join("./", folder, "history.pkl"), "rb") as f:
         history_dict = pickle.load(f) 
     
-    assert "val_preds_acc" in history_dict.keys(), "val_preds_acc not available for ", folder
+    assert "val_preds_acc" in history_dict.keys(), "val_preds_acc not available "
     plt.plot(np.arange(50), history_dict["val_preds_acc"])
 plt.show() 
 

--- a/VIZ_mnist_runs.py
+++ b/VIZ_mnist_runs.py
@@ -19,7 +19,7 @@ for folder in clean_files:
         history_dict = pickle.load(f) 
     
     assert "val_preds_acc" in history_dict.keys(), "val_preds_acc not available "
-    plt.plot(np.arange(50), history_dict["val_preds_acc"], label=parameters_str)
+    plt.plot(np.arange(20), history_dict["val_preds_acc"], label=parameters_str)
 plt.legend() 
 plt.show() 
 

--- a/loss_layers.py
+++ b/loss_layers.py
@@ -50,17 +50,20 @@ def wrapper_categorical_crossentropy(num_triplets):
     """
     select_anchors = lambda x: x[:num_triplets, :]
     select_negatives = lambda x: x[num_triplets*2 : num_triplets*3, :]
+    select_positives = lambda x: x[num_triplets : num_triplets*2, :] 
 
     def custom_cat_ce(y_true, y_pred):
         true_ancs = Lambda(select_anchors)(y_true)
         true_negs = Lambda(select_negatives)(y_true)
+        true_poss = Lambda(select_positives)(y_true)
 
         pred_ancs = Lambda(select_anchors)(y_pred)
         pred_negs = Lambda(select_negatives)(y_pred)
+        pred_poss = Lambda(select_positives)(y_pred) 
 
         return K.categorical_crossentropy(
-            concatenate([true_ancs, true_negs]),
-            concatenate([pred_ancs, pred_negs])
+            concatenate([true_ancs, true_negs, true_poss]),
+            concatenate([pred_ancs, pred_negs, pred_poss])
         )
 
     return custom_cat_ce

--- a/run_all_mnist.sh
+++ b/run_all_mnist.sh
@@ -1,0 +1,7 @@
+python TEST_TripleReg_mnist.py ./run1/ 0.0 1.0 
+python TEST_TripleReg_mnist.py ./run2/ 0.2 1.0 
+python TEST_TripleReg_mnist.py ./run3/ 0.4 1.0 
+python TEST_TripleReg_mnist.py ./run4/ 0.6 1.0 
+python TEST_TripleReg_mnist.py ./run5/ 0.8 1.0 
+python TEST_TripleReg_mnist.py ./run6/ 1.0 1.0 
+python TEST_TripleReg_mnist.py ./run7/ 0.5 0.5 


### PR DESCRIPTION
TEST_TripletReg_mnist.py: epochs = 20, steps per epoch = 20. No Branch for embeds, triplet loss directly on features. 
VIZ_mnist: looks for all "./run*/ folders in the current directory and plots the validation accuracy curve with the legend of the parameters of the run. 
mnist_run_all.sh : Convenience script, runs the TEST... script with various different hyper-parameters. 